### PR TITLE
Add mypy config file

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -32,6 +32,6 @@ lint = "python .scripts/lint.py"
 pslint = "Powershell.exe -File .scripts/lint.ps1"
 lint-imports = "isort main.py mimic"
 lint-code = "autopep8 --in-place --recursive main.py mimic"
-lint-type_checking = "mypy main.py mimic --ignore-missing-imports"
+lint-type_checking = "mypy main.py mimic --config-file mypy.ini"
 lint-docstring = "pydocstyle main.py mimic"
 debug-ios = "remotedebug_ios_webkit_adapter --port=9000" # Requires that the package is installed and configured https://github.com/RemoteDebug/remotedebug-ios-webkit-adapter

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,7 @@
+[mypy]
+warn_unused_configs = True
+ignore_missing_imports = True
+warn_unused_ignores = True
+warn_unreachable = True
+warn_no_return = True
+


### PR DESCRIPTION
Added back in the mypy config file that was lost on one of the branches. I guess the codebase is already up-to-date with typings already so nothing needed changed with typings.