### PR TITLE
Detect closed connections on the client

### DIFF
--- a/mimic/public/app.js
+++ b/mimic/public/app.js
@@ -156,44 +156,6 @@ async function negotiate(peerConnection) {
 }
 
 /**
- * Test data channel that sends ping/pong messages
- */
-class PingPongDataChannel {
-    /**
-     * Establish ping pong data channel over RTC peer connection
-     * @param {RTCPeerConnection} peerConnection Instance of `RTCPeerConnection` that has already been negotiated
-     */
-    constructor(peerConnection) {
-        this.interval = null
-        this.dataChannel = peerConnection.createDataChannel('chat', {
-            ordered: true
-        })
-
-        this.dataChannel.onopen = this.onOpen.bind(this)
-        this.dataChannel.onclose = this.onClose.bind(this)
-        this.dataChannel.onmessage = this.onMessage.bind(this)
-    }
-
-    onOpen() {
-        debugLog('Ping Pong Data Channel', '- open')
-        this.interval = setInterval(() => {
-            const message = 'ping ' + new Date().getTime()
-            debugLog('Ping Pong Data Channel', '> ' + message)
-            this.dataChannel.send(message)
-        }, 1000)
-    }
-
-    onClose() {
-        clearInterval(this.interval)
-        debugLog('Ping Pong Data Channel', '- close')
-    }
-
-    onMessage(event) {
-        debugLog('Ping Pong Data Channel', '< ' + event.data)
-    }
-}
-
-/**
  * Data channel that sends metadata about the video stream
  */
 class MetadataDataChannel {

--- a/mimic/public/app.js
+++ b/mimic/public/app.js
@@ -341,7 +341,7 @@ async function main() {
     let videoPreviewElement = document.getElementById('video-preview')
     videoPreviewElement.srcObject = mediaDevices
 
-    if (mediaStream.getVideoTracks().length < 0) {
+    if (mediaDevices.getVideoTracks().length < 0) {
         throw new Error(
             'Could not access video track, try refreshing the page.'
         )

--- a/mimic/public/app.js
+++ b/mimic/public/app.js
@@ -1,5 +1,5 @@
 // Milliseconds to wait before resfreshing the page on error
-const RESFRESH_TIMEOUT = 1000
+const REFRESH_TIMEOUT = 1000
 
 // Default video constraints
 CONSTRAINTS = {


### PR DESCRIPTION
## Notable Changes

-   Detect stale connections after 5 seconds on the client
-   Notify user when connection is lost on client
-   Fix `REFRESH_TIMEOUT` is not defined
-   Fix `mediaStream` is not defined

## Changelog

-   Use mediaDevices instead of mediaStream
-   Remove PingPongDataChannel
-   Fix REFRESH_TIMEOUT not defined
-   Close stale connection after five seconds and notify user
