### PR TITLE
Use fork of pyvirtualcam

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -12,9 +12,9 @@ pythonlangutil = "*"
 "infi.systray" = "*"
 pyqrcode = "*"
 pyopenssl = "*"
-pyvirtualcam = "==0.3.2"
 pyinstaller = "==4.2"
 pywin32 = "*"
+pyvirtualcam = {file = "https://github.com/link00000000/pyvirtualcam/releases/download/v0.4.0/pyvirtualcam-0.3.2-cp39-cp39-win_amd64.whl"}
 
 [dev-packages]
 autopep8 = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "688ba93a0c16714cc675309dec1939ba6be5633c45a3863b463d4d0c87ff159e"
+            "sha256": "afd9707ae4b020c6c81753432b8589746a7315183a794005c4cb06867a03c81f"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -565,8 +565,10 @@
             "version": "==0.1"
         },
         "pyvirtualcam": {
+            "file": "https://github.com/link00000000/pyvirtualcam/releases/download/v0.4.0/pyvirtualcam-0.3.2-cp39-cp39-win_amd64.whl",
             "hashes": [
                 "sha256:340432425023cc34091bdfc3b4a94dc6993fae6bb1a534102ab2190fbb876738",
+                "sha256:5ec34a8848985b720f39f10bf55f220b790fead5cf7b5270fd6fbf4433009f6c",
                 "sha256:6a40e0e7176de19d7669ac450cc64b3f499e36c1b2e957053dd6cf2ac678e64e",
                 "sha256:b3174ad2471d55eeb449ae056d85c862fe7e7aec577a689b064bc6bb03bf0061",
                 "sha256:f92d40f45d5fb83ca2edd3304532ef4d5f8ad3d0cee32378dcb63e67c7d98938"
@@ -798,38 +800,38 @@
         },
         "typed-ast": {
             "hashes": [
-                "sha256:07d49388d5bf7e863f7fa2f124b1b1d89d8aa0e2f7812faff0a5658c01c59aa1",
-                "sha256:14bf1522cdee369e8f5581238edac09150c765ec1cb33615855889cf33dcb92d",
-                "sha256:240296b27397e4e37874abb1df2a608a92df85cf3e2a04d0d4d61055c8305ba6",
-                "sha256:36d829b31ab67d6fcb30e185ec996e1f72b892255a745d3a82138c97d21ed1cd",
-                "sha256:37f48d46d733d57cc70fd5f30572d11ab8ed92da6e6b28e024e4a3edfb456e37",
-                "sha256:4c790331247081ea7c632a76d5b2a265e6d325ecd3179d06e9cf8d46d90dd151",
-                "sha256:5dcfc2e264bd8a1db8b11a892bd1647154ce03eeba94b461effe68790d8b8e07",
-                "sha256:7147e2a76c75f0f64c4319886e7639e490fee87c9d25cb1d4faef1d8cf83a440",
-                "sha256:7703620125e4fb79b64aa52427ec192822e9f45d37d4b6625ab37ef403e1df70",
-                "sha256:8368f83e93c7156ccd40e49a783a6a6850ca25b556c0fa0240ed0f659d2fe496",
-                "sha256:84aa6223d71012c68d577c83f4e7db50d11d6b1399a9c779046d75e24bed74ea",
-                "sha256:85f95aa97a35bdb2f2f7d10ec5bbdac0aeb9dafdaf88e17492da0504de2e6400",
-                "sha256:8db0e856712f79c45956da0c9a40ca4246abc3485ae0d7ecc86a20f5e4c09abc",
-                "sha256:9044ef2df88d7f33692ae3f18d3be63dec69c4fb1b5a4a9ac950f9b4ba571606",
-                "sha256:963c80b583b0661918718b095e02303d8078950b26cc00b5e5ea9ababe0de1fc",
-                "sha256:987f15737aba2ab5f3928c617ccf1ce412e2e321c77ab16ca5a293e7bbffd581",
-                "sha256:9ec45db0c766f196ae629e509f059ff05fc3148f9ffd28f3cfe75d4afb485412",
-                "sha256:9fc0b3cb5d1720e7141d103cf4819aea239f7d136acf9ee4a69b047b7986175a",
-                "sha256:a2c927c49f2029291fbabd673d51a2180038f8cd5a5b2f290f78c4516be48be2",
-                "sha256:a38878a223bdd37c9709d07cd357bb79f4c760b29210e14ad0fb395294583787",
-                "sha256:b4fcdcfa302538f70929eb7b392f536a237cbe2ed9cba88e3bf5027b39f5f77f",
-                "sha256:c0c74e5579af4b977c8b932f40a5464764b2f86681327410aa028a22d2f54937",
-                "sha256:c1c876fd795b36126f773db9cbb393f19808edd2637e00fd6caba0e25f2c7b64",
-                "sha256:c9aadc4924d4b5799112837b226160428524a9a45f830e0d0f184b19e4090487",
-                "sha256:cc7b98bf58167b7f2db91a4327da24fb93368838eb84a44c472283778fc2446b",
-                "sha256:cf54cfa843f297991b7388c281cb3855d911137223c6b6d2dd82a47ae5125a41",
-                "sha256:d003156bb6a59cda9050e983441b7fa2487f7800d76bdc065566b7d728b4581a",
-                "sha256:d175297e9533d8d37437abc14e8a83cbc68af93cc9c1c59c2c292ec59a0697a3",
-                "sha256:d746a437cdbca200622385305aedd9aef68e8a645e385cc483bdc5e488f07166",
-                "sha256:e683e409e5c45d5c9082dc1daf13f6374300806240719f95dc783d1fc942af10"
+                "sha256:01ae5f73431d21eead5015997ab41afa53aa1fbe252f9da060be5dad2c730ace",
+                "sha256:067a74454df670dcaa4e59349a2e5c81e567d8d65458d480a5b3dfecec08c5ff",
+                "sha256:0fb71b8c643187d7492c1f8352f2c15b4c4af3f6338f21681d3681b3dc31a266",
+                "sha256:1b3ead4a96c9101bef08f9f7d1217c096f31667617b58de957f690c92378b528",
+                "sha256:2068531575a125b87a41802130fa7e29f26c09a2833fea68d9a40cf33902eba6",
+                "sha256:209596a4ec71d990d71d5e0d312ac935d86930e6eecff6ccc7007fe54d703808",
+                "sha256:2c726c276d09fc5c414693a2de063f521052d9ea7c240ce553316f70656c84d4",
+                "sha256:398e44cd480f4d2b7ee8d98385ca104e35c81525dd98c519acff1b79bdaac363",
+                "sha256:52b1eb8c83f178ab787f3a4283f68258525f8d70f778a2f6dd54d3b5e5fb4341",
+                "sha256:5feca99c17af94057417d744607b82dd0a664fd5e4ca98061480fd8b14b18d04",
+                "sha256:7538e495704e2ccda9b234b82423a4038f324f3a10c43bc088a1636180f11a41",
+                "sha256:760ad187b1041a154f0e4d0f6aae3e40fdb51d6de16e5c99aedadd9246450e9e",
+                "sha256:777a26c84bea6cd934422ac2e3b78863a37017618b6e5c08f92ef69853e765d3",
+                "sha256:95431a26309a21874005845c21118c83991c63ea800dd44843e42a916aec5899",
+                "sha256:9ad2c92ec681e02baf81fdfa056fe0d818645efa9af1f1cd5fd6f1bd2bdfd805",
+                "sha256:9c6d1a54552b5330bc657b7ef0eae25d00ba7ffe85d9ea8ae6540d2197a3788c",
+                "sha256:aee0c1256be6c07bd3e1263ff920c325b59849dc95392a05f258bb9b259cf39c",
+                "sha256:af3d4a73793725138d6b334d9d247ce7e5f084d96284ed23f22ee626a7b88e39",
+                "sha256:b36b4f3920103a25e1d5d024d155c504080959582b928e91cb608a65c3a49e1a",
+                "sha256:b9574c6f03f685070d859e75c7f9eeca02d6933273b5e69572e5ff9d5e3931c3",
+                "sha256:bff6ad71c81b3bba8fa35f0f1921fb24ff4476235a6e94a26ada2e54370e6da7",
+                "sha256:c190f0899e9f9f8b6b7863debfb739abcb21a5c054f911ca3596d12b8a4c4c7f",
+                "sha256:c907f561b1e83e93fad565bac5ba9c22d96a54e7ea0267c708bffe863cbe4075",
+                "sha256:cae53c389825d3b46fb37538441f75d6aecc4174f615d048321b716df2757fb0",
+                "sha256:dd4a21253f42b8d2b48410cb31fe501d32f8b9fbeb1f55063ad102fe9c425e40",
+                "sha256:dde816ca9dac1d9c01dd504ea5967821606f02e510438120091b84e852367428",
+                "sha256:f2362f3cb0f3172c42938946dbc5b7843c2a28aec307c49100c8b38764eb6927",
+                "sha256:f328adcfebed9f11301eaedfa48e15bdece9b519fb27e6a8c01aa52a17ec31b3",
+                "sha256:f8afcf15cc511ada719a88e013cec87c11aff7b91f019295eb4530f96fe5ef2f",
+                "sha256:fb1bbeac803adea29cedd70781399c99138358c26d05fcbd23c13016b7f5ec65"
             ],
-            "version": "==1.4.2"
+            "version": "==1.4.3"
         },
         "typing-extensions": {
             "hashes": [

--- a/mimic/WebServer.py
+++ b/mimic/WebServer.py
@@ -22,7 +22,6 @@ import json
 import logging
 import os
 import ssl
-import time
 from json.decoder import JSONDecodeError
 from mimetypes import MimeTypes
 from multiprocessing.connection import Connection
@@ -39,11 +38,12 @@ from aiortc.exceptions import InvalidStateError
 from aiortc.mediastreams import MediaStreamError
 from aiortc.rtcdatachannel import RTCDataChannel
 from aiortc.rtcpeerconnection import RemoteStreamTrack
+from av import VideoFrame
+from av.video.reformatter import VideoReformatter
 from PIL import Image
 from pyvirtualcam.camera import _WindowsCamera
 
 from mimic.Constants import SLEEP_INTERVAL
-from mimic.MetaData import MetaData
 from mimic.Pipeable import LogMessage
 from mimic.Utils.Host import resolve_host
 from mimic.Utils.SSL import generate_ssl_certs, ssl_certs_generated
@@ -54,16 +54,27 @@ ASSETS_ROOT = "assets"
 
 _STALE_CONNECTION_TIMEOUT = 5.0
 _PING_INTERVAL = 1.0
-_MAX_CAMERA_INIT_RETRY = 5
+_MAX_CAMERA_RETRY_COUNT = 5
 _CAMERA_INIT_RETRY_INTERVAL = 1
+
+_CAMERA_WIDTH = 1280
+_CAMERA_HEIGHT = 720
+_CAMERA_FPS = 30
+_CAMERA_DELAY = 0
 
 _MIMETYPES = MimeTypes()
 
 cam: Optional[_WindowsCamera] = None
 is_cam_idle = True
 
-_NO_CAMERA_IMAGE = np.asarray(Image.open(
-    os.path.join(ASSETS_ROOT, "no_camera.bmp")).convert('RGBA'), dtype=np.uint8)
+# Store a global referece to the reformatter for performance
+# See https://pyav.org/docs/stable/api/video.html#av.video.reformatter.VideoReformatter
+_VIDEO_REFORMATTER = VideoReformatter()
+
+_NO_CAMREA_IMAGE_BMP = Image.open(os.path.join(ASSETS_ROOT, "no_camera.bmp")).convert('RGB')
+_NO_CAMERA_IMAGE_FRAME = VideoFrame.from_ndarray(np.asanyarray(_NO_CAMREA_IMAGE_BMP, dtype=np.uint8), format="rgb24").reformat(
+    width=_CAMERA_WIDTH, height=_CAMERA_HEIGHT, format='rgba')
+_NO_CAMERA_IMAGE_NDARRAY = _NO_CAMERA_IMAGE_FRAME.to_ndarray()
 
 
 async def start_web_server(stop_event: Event, pipe: Connection) -> None:
@@ -91,8 +102,8 @@ async def start_web_server(stop_event: Event, pipe: Connection) -> None:
         # Format is a 2d array containing an RGBA tuples
         # 640x480
         if cam is not None:
-            frame_array = frame.to_ndarray(format="rgba")
-            cam.send(frame_array)
+            frame = _VIDEO_REFORMATTER.reformat(frame=frame, width=_CAMERA_WIDTH, height=_CAMERA_HEIGHT, format="rgba")
+            cam.send(frame.to_ndarray())
 
         # @NOTE Not sure if we need this but I'm going to leave it in case we
         # ever need a case for it
@@ -100,13 +111,10 @@ async def start_web_server(stop_event: Event, pipe: Connection) -> None:
 
     def show_static_frame() -> None:
         """Paint static image to camera frame buffer."""
-        buffer_height, buffer_width = _NO_CAMERA_IMAGE.shape[:2]
-
-        global cam
         if cam is None:
-            cam = pyvirtualcam.Camera(buffer_width, buffer_height, 20)
+            raise RuntimeError('Trying to send frame to camera before initialization')
 
-        cam.send(_NO_CAMERA_IMAGE)
+        cam.send(_NO_CAMERA_IMAGE_NDARRAY)
 
     def log(message: str, level: int = logging.INFO):
         """
@@ -125,15 +133,10 @@ async def start_web_server(stop_event: Event, pipe: Connection) -> None:
         Returns:
             int: Number of connections that were closed
         """
-        global cam
-        if cam is not None:
-            cam.close()
-            cam = None
+        global is_cam_idle
+        is_cam_idle = True
 
-            global is_cam_idle
-            is_cam_idle = True
-
-        for pc in pcs:
+        for pc in pcs.copy():
             await pc.close()
 
         num_pcs = len(pcs)
@@ -205,6 +208,9 @@ async def start_web_server(stop_event: Event, pipe: Connection) -> None:
                         # and the rolling timout should be started
                         if message == '-1':
                             heartbeat_timeout.start()
+
+                            global is_cam_idle
+                            is_cam_idle = False
                         else:
                             round_trip_time = latency(int(message))
                             log(f"Latency {round_trip_time}ms", logging.DEBUG)
@@ -219,54 +225,6 @@ async def start_web_server(stop_event: Event, pipe: Connection) -> None:
                             # raising an `InvalidStateError`. We should just
                             # ignore those.
                             pass
-
-                    if channel.label == 'metadata':
-                        try:
-                            metadata = MetaData(message)
-
-                            try:
-                                global cam
-                                if cam is not None:
-                                    cam.close()
-                                    cam = None
-
-                                log(f"Start camera with metadata: {metadata.width}x{metadata.height}@{metadata.framerate}",
-                                    logging.DEBUG)
-
-                                global is_cam_idle
-                                is_cam_idle = False
-
-                                # HWND needs time to free before allocation of new camera
-                                # See: https://github.com/link00000000/mimic/issues/41
-                                for _ in range(_MAX_CAMERA_INIT_RETRY):
-                                    try:
-                                        cam = pyvirtualcam.Camera(
-                                            metadata.width, metadata.height, metadata.framerate, delay=0)
-                                        break
-                                    except RuntimeError as error:
-                                        if error.args[0] != "error starting virtual camera output":
-                                            raise error
-
-                                        log("Failed to acquire camera, trying again...",
-                                            logging.WARNING)
-
-                                        # If we were unable to acquire the camera, wait for some time and try
-                                        # again
-                                        time.sleep(_CAMERA_INIT_RETRY_INTERVAL)
-
-                                # If we could not acquire the camera after a few tries, raise an exception
-                                if cam is None:
-                                    raise RuntimeError(
-                                        "error starting virtual camera output")
-
-                            except RuntimeError as error:
-                                log(str(error), logging.ERROR)
-                                cam = None
-                                await close_all_connections()
-
-                        except (KeyError, TypeError, JSONDecodeError) as error:
-                            log(str(error), logging.ERROR)
-                            await close_all_connections()
 
         @pc.on("connectionstatechange")
         async def on_connectionstatechange():
@@ -287,13 +245,8 @@ async def start_web_server(stop_event: Event, pipe: Connection) -> None:
             async def on_ended():
                 log(f"Track {track.kind} ended")
 
-                global cam
-                if cam is not None:
-                    cam.close()
-                    cam = None
-
-                    global is_cam_idle
-                    is_cam_idle = True
+                global is_cam_idle
+                is_cam_idle = True
 
             while True:
                 if track.readyState != "live":
@@ -342,6 +295,25 @@ async def start_web_server(stop_event: Event, pipe: Connection) -> None:
 
     log(f"Server listening at https://{resolve_host()}:8080")
 
+    # Acquire virtual camera
+    camera_init_sucess = False
+    for _ in range(_MAX_CAMERA_RETRY_COUNT):
+        global cam
+        try:
+            cam = pyvirtualcam.Camera(_CAMERA_WIDTH, _CAMERA_HEIGHT, _CAMERA_FPS, _CAMERA_DELAY)
+            camera_init_sucess = True
+            break
+
+        except RuntimeError as error:
+            if error.args[0] != 'error starting virtual camera output':
+                raise error
+
+            log("Failed to acquire camera, retrying.", logging.WARN)
+            await asyncio.sleep(_CAMERA_INIT_RETRY_INTERVAL)
+
+    if not camera_init_sucess:
+        raise RuntimeError("Failed to acquire camera.", logging.ERROR)
+
     # Main loop
     while stop_event is None or not stop_event.is_set():
         if is_cam_idle:
@@ -376,6 +348,6 @@ def webserver_thread_runner(stop_event: Event, pipe: Connection):
     """
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
-    loop.set_exception_handler(lambda loop, context: print(loop, context))
+    loop.set_exception_handler(lambda loop, context: stop_event.set())
 
     loop.run_until_complete(start_web_server(stop_event, pipe))

--- a/mimic/WebServer.py
+++ b/mimic/WebServer.py
@@ -12,9 +12,6 @@ RTC data channels:
   every `_PING_INTERVAL` seconds to make sure the connection is still alive and
   record round time time in
   milliseconds
-- metadata - A single message is sent from the client during initial connection
-  containing a JSON object with information about the video stream (see `MetaData`)
-- 
 """
 
 import asyncio

--- a/mimic/public/app.js
+++ b/mimic/public/app.js
@@ -156,44 +156,6 @@ async function negotiate(peerConnection) {
 }
 
 /**
- * Test data channel that sends ping/pong messages
- */
-class PingPongDataChannel {
-    /**
-     * Establish ping pong data channel over RTC peer connection
-     * @param {RTCPeerConnection} peerConnection Instance of `RTCPeerConnection` that has already been negotiated
-     */
-    constructor(peerConnection) {
-        this.interval = null
-        this.dataChannel = peerConnection.createDataChannel('chat', {
-            ordered: true
-        })
-
-        this.dataChannel.onopen = this.onOpen.bind(this)
-        this.dataChannel.onclose = this.onClose.bind(this)
-        this.dataChannel.onmessage = this.onMessage.bind(this)
-    }
-
-    onOpen() {
-        debugLog('Ping Pong Data Channel', '- open')
-        this.interval = setInterval(() => {
-            const message = 'ping ' + new Date().getTime()
-            debugLog('Ping Pong Data Channel', '> ' + message)
-            this.dataChannel.send(message)
-        }, 1000)
-    }
-
-    onClose() {
-        clearInterval(this.interval)
-        debugLog('Ping Pong Data Channel', '- close')
-    }
-
-    onMessage(event) {
-        debugLog('Ping Pong Data Channel', '< ' + event.data)
-    }
-}
-
-/**
  * Data channel that sends metadata about the video stream
  */
 class MetadataDataChannel {

--- a/mimic/public/app.js
+++ b/mimic/public/app.js
@@ -341,7 +341,7 @@ async function main() {
     let videoPreviewElement = document.getElementById('video-preview')
     videoPreviewElement.srcObject = mediaDevices
 
-    if (mediaStream.getVideoTracks().length < 0) {
+    if (mediaDevices.getVideoTracks().length < 0) {
         throw new Error(
             'Could not access video track, try refreshing the page.'
         )

--- a/mimic/public/app.js
+++ b/mimic/public/app.js
@@ -1,5 +1,5 @@
 // Milliseconds to wait before resfreshing the page on error
-const RESFRESH_TIMEOUT = 1000
+const REFRESH_TIMEOUT = 1000
 
 // Default video constraints
 CONSTRAINTS = {


### PR DESCRIPTION
# Depends on #65

## Notable Changes

-   Replaces the pyvirtualcam dependency with [a custom fork of pyvirtualcam](https://github.com/link00000000/pyvirtualcam) ([click here for diff](https://github.com/letmaik/pyvirtualcam/compare/v0.3.2...link00000000:master))
    -   Fork of pyvirtualcam will do the following
        -   Try to use old shared memory buffer if it already exists
        -   Create new shared memory buffer if one does not exist
        -   When the last writer process stop using shared memory buffer, close it
        -   Bump python version to 3.9 and numpy version to 1.19 in CI
    -   Allows multiple writers to the same share memory buffer
        -   This elimates issues of trying to acquire the buffer and it being already busy because some reader processes won't free the buffer
        -   This also means that the feeds can be switched while reading simultaneously

## Changelog

-   Use mediaDevices instead of mediaStream
-   Remove PingPongDataChannel
-   Fix REFRESH_TIMEOUT not defined
-   Close stale connection after five seconds and notify user
-   Use a single instace of pyvirtualcam instead of replacing it during runtime
-   Remove metadata data channel
-   Use fork of pyvirtualcam as dependency
